### PR TITLE
Fixes #85

### DIFF
--- a/schemas/oval-definitions-schema.xsd
+++ b/schemas/oval-definitions-schema.xsd
@@ -969,6 +969,11 @@
                     <xsd:documentation>The seconds_since_epoch value specifies date-time values that represent the time in seconds since the UNIX epoch.  The Unix epoch is the time 00:00:00 UTC on January 1, 1970.</xsd:documentation>
                 </xsd:annotation>
             </xsd:enumeration>
+            <xsd:enumeration value="cim_datetime">
+                <xsd:annotation>
+                    <xsd:documentation>The cim_datetime model is used by WMI and its value specifies date-time strings that follow the format: 'yyyymmddHHMMSS.mmmmmmsUUU', and alternatively 'yyyy-mm-dd HH:MM:SS:mmm' only when used in WMI Query Language queries.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
         </xsd:restriction>
     </xsd:simpleType>
     <xsd:simpleType name="FilterActionEnumeration">


### PR DESCRIPTION
Added the CIM_DATETIME WMI date format to the
oval-def:DateTimeFormatEnumeration.
