### PR TITLE
Edit unix-def:shadow_test flag entity documentation.

### DIFF
--- a/schemas/unix-definitions-schema.xsd
+++ b/schemas/unix-definitions-schema.xsd
@@ -2019,9 +2019,9 @@
                                                 <xsd:documentation>This specifies when will the account's password expire, in days since 1/1/1970.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
-                                    <xsd:element name="flag" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                                    <xsd:element name="flag" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
-                                                <xsd:documentation>This is a reserved field that the shadow file may use in the future. An numeric value should be used for this field.</xsd:documentation>
+                                                <xsd:documentation>This is a reserved field that the shadow file may use in the future. A numeric value should be used for this field.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
                                     <xsd:element name="encrypt_method" type="unix-def:EntityStateEncryptMethodType" minOccurs="0" maxOccurs="1">

--- a/schemas/unix-definitions-schema.xsd
+++ b/schemas/unix-definitions-schema.xsd
@@ -2021,7 +2021,7 @@
                                     </xsd:element>
                                     <xsd:element name="flag" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
-                                                <xsd:documentation>This is a reserved field that the shadow file may use in the future.</xsd:documentation>
+                                                <xsd:documentation>This is a reserved field that the shadow file may use in the future. An numeric value should be used for this field.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
                                     <xsd:element name="encrypt_method" type="unix-def:EntityStateEncryptMethodType" minOccurs="0" maxOccurs="1">

--- a/schemas/unix-system-characteristics-schema.xsd
+++ b/schemas/unix-system-characteristics-schema.xsd
@@ -800,9 +800,9 @@
                                         <xsd:documentation>This specifies when will the account's password expire, in days since 1/1/1970.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
-                              <xsd:element name="flag" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                              <xsd:element name="flag" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>This is a reserved field that the shadow file may use in the future.  An numeric value should be used for this field.</xsd:documentation>
+                                        <xsd:documentation>This is a reserved field that the shadow file may use in the future.  A numeric value should be used for this field.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="encrypt_method" type="unix-sc:EntityItemEncryptMethodType" minOccurs="0" maxOccurs="1">

--- a/schemas/unix-system-characteristics-schema.xsd
+++ b/schemas/unix-system-characteristics-schema.xsd
@@ -802,7 +802,7 @@
                               </xsd:element>
                               <xsd:element name="flag" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
-                                        <xsd:documentation>This is a reserved field that the shadow file may use in the future.</xsd:documentation>
+                                        <xsd:documentation>This is a reserved field that the shadow file may use in the future.  An numeric value should be used for this field.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="encrypt_method" type="unix-sc:EntityItemEncryptMethodType" minOccurs="0" maxOccurs="1">


### PR DESCRIPTION
Add additional information to use numeric value for the flag field.
Issue #74

	modified:   schemas/unix-definitions-schema.xsd