### PR TITLE
fixes #55

### DIFF
--- a/schemas/windows-system-characteristics-schema.xsd
+++ b/schemas/windows-system-characteristics-schema.xsd
@@ -2005,7 +2005,7 @@
                               </xsd:element>
                               <xsd:element name="key" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1" nillable="true">
                                    <xsd:annotation>
-                                        <xsd:documentation>This element describes a registry key to be gathered. Note that the hive portion of the string should not be inclueded, as this data can be found under the hive element. If the xsi:nil attribute is set to true, then the item being represented is the higher level hive or lower level name. Using xsi:nil here will result in a status of 'not collected' for this entity since the item is specific to a hive or name.</xsd:documentation>
+                                        <xsd:documentation>This element describes a registry key to be gathered. Note that the hive portion of the string should not be included, as this data can be found under the hive element. If the xsi:nil attribute is set to true, then the item being represented is the higher level hive or lower level name. Using xsi:nil here will result in a status of 'not collected' for this entity since the item is specific to a hive or name.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
                               <xsd:element name="name" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1" nillable="true">


### PR DESCRIPTION
changed documentation to for multiple nillable entities to read 'not
collected' instead of 'does not exist'.
