### PR TITLE
Schema updates for Cisco ASA, IOS, IOS-XE and MacOS

### DIFF
--- a/schemas/asa-definitions-schema.xsd
+++ b/schemas/asa-definitions-schema.xsd
@@ -7,7 +7,7 @@
             <xsd:documentation>Thanks to Omar Santos and Panos Kampanakis of Cisco for providing these tests.</xsd:documentation>
             <xsd:appinfo>
                   <schema>Cisco ASA Definition</schema>
-                  <version>5.11.1:1.1</version>
+                  <version>5.11.1:1.2</version>
                   <date>4/22/2015 09:00:00 AM</date>
                   <terms_of_use>Copyright (c) 2002-2015, The MITRE Corporation. All rights reserved. The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema. When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
                   <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5" />

--- a/schemas/asa-system-characteristics-schema.xsd
+++ b/schemas/asa-system-characteristics-schema.xsd
@@ -7,7 +7,7 @@
             <xsd:documentation>Thanks to Omar Santos and Panos Kampanakis of Cisco for providing these tests.</xsd:documentation>
             <xsd:appinfo>
                   <schema>Cisco ASA System Characteristics</schema>
-                  <version>5.11.1:1.1</version>
+                  <version>5.11.1:1.2</version>
                   <date>4/22/2015 09:00:00 AM</date>
                   <terms_of_use>Copyright (c) 2002-2015, The MITRE Corporation. All rights reserved. The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema. When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
                   <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>

--- a/schemas/asa-system-characteristics-schema.xsd
+++ b/schemas/asa-system-characteristics-schema.xsd
@@ -36,12 +36,12 @@
                                                 <xsd:documentation>Element with the IP version of the ACL.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
-                                    <xsd:element name="use" type="asa-sc:EntityItemAccessListUseType" minOccurs="0" maxOccurs="unbounded">
+                                    <xsd:element name="use" type="asa-sc:EntityItemAccessListUseType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
                                                 <xsd:documentation>Element with the feature where the ACL is used. If the same ACL is applied in more than one feature (i.e interface and crypto map), multiple items needs to be created.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
-                                    <xsd:element name="used_in" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
+                                    <xsd:element name="used_in" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
                                                 <xsd:documentation>Element with the name of where the ACL is used. For example if use is 'INTERFACE', use_in will be the name of the interface. If the same ACL is applied in more than one feature (i.e interface and crypto map), multiple items needs to be created.</xsd:documentation>
                                           </xsd:annotation>

--- a/schemas/asa-system-characteristics-schema.xsd
+++ b/schemas/asa-system-characteristics-schema.xsd
@@ -262,7 +262,7 @@
                                                 <xsd:documentation>Element with the inspection type of the class-map.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
-                                    <xsd:element name="parameters" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                    <xsd:element name="parameters" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
                                           <xsd:annotation>
                                                 <xsd:documentation>Element with the parameter commands of the policy-map.</xsd:documentation>
                                           </xsd:annotation>
@@ -442,7 +442,7 @@
                                                 <xsd:documentation>Element with the tcp-map name.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
-                                    <xsd:element name="options" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                    <xsd:element name="options" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
                                           <xsd:annotation>
                                                 <xsd:documentation>Element with the configured commends in the tcp-map. These could include TCP options, flags and other options of the tcp-map.</xsd:documentation>
                                           </xsd:annotation>

--- a/schemas/asa-system-characteristics-schema.xsd
+++ b/schemas/asa-system-characteristics-schema.xsd
@@ -98,12 +98,12 @@
                                                 <xsd:documentation>Element with the 'match-all' or 'match-any' type of the class-map. ASA's defaults to 'match-any'.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
-                                    <xsd:element name="match" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                    <xsd:element name="match" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
                                           <xsd:annotation>
                                                 <xsd:documentation>Element with the match command in the class-map.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
-                                    <xsd:element name="used_in_class_map" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                    <xsd:element name="used_in_class_map" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
                                           <xsd:annotation>
                                                 <xsd:documentation>Element with the name of the class-map (for nested class-maps) that this class-map is used in.</xsd:documentation>
                                           </xsd:annotation>
@@ -113,7 +113,7 @@
                                                 <xsd:documentation>Element with the name of the policy-map that this class-map is used in.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
-                                    <xsd:element name="policy_map_action" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                    <xsd:element name="policy_map_action" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
                                           <xsd:annotation>
                                                 <xsd:documentation>Element with the command that identifies the action for the class. For example that could be 'inspect protocolX', 'drop' or 'police 1000' or 'set connection advanced-options tcpmapX'.</xsd:documentation>
                                           </xsd:annotation>
@@ -267,7 +267,7 @@
                                                 <xsd:documentation>Element with the parameter commands of the policy-map.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
-                                    <xsd:element name="match_action" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                                    <xsd:element name="match_action" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="unbounded">
                                           <xsd:annotation>
                                                 <xsd:documentation>Element with the in-line match command and the action in the policy-map seperated by delimeter '_-_'. For example an http inspect policy-map could have 'match body regex regexnameX' and the action be 'drop'. Then this element would be 'body regex regexnameX_-_drop'.</xsd:documentation>
                                           </xsd:annotation>

--- a/schemas/ios-definitions-schema.xsd
+++ b/schemas/ios-definitions-schema.xsd
@@ -7,7 +7,7 @@
             <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
             <xsd:appinfo>
                   <schema>IOS Definition</schema>
-                  <version>5.11.1:1.1</version>
+                  <version>5.11.1:1.2</version>
                   <date>4/22/2015 09:00:00 AM</date>
                   <terms_of_use>Copyright (c) 2002-2015, The MITRE Corporation. All rights reserved.  The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema.  When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
                    <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>

--- a/schemas/ios-definitions-schema.xsd
+++ b/schemas/ios-definitions-schema.xsd
@@ -818,10 +818,24 @@
                                                 <xsd:documentation>The BGP neighbors, if applicable.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
-                                    <xsd:element name="ospf_authentication_area" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                                    <xsd:element name="ospf_authentication_area" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
                                                 <xsd:documentation>The OSPF area that is authenticated, if applicable.</xsd:documentation>
                                           </xsd:annotation>
+                                          <xsd:complexType>
+                                                <xsd:simpleContent>
+                                                      <xsd:restriction base="oval-def:EntityStateAnySimpleType">
+                                                            <xsd:attribute name="datatype" use="optional" default="int">
+                                                                  <xsd:simpleType>
+                                                                        <xsd:restriction base="oval:SimpleDatatypeEnumeration">
+                                                                              <xsd:enumeration value="int"/>
+                                                                              <xsd:enumeration value="ipv4_address"/>
+                                                                        </xsd:restriction>
+                                                                  </xsd:simpleType>
+                                                            </xsd:attribute>
+                                                      </xsd:restriction>
+                                                </xsd:simpleContent>
+                                          </xsd:complexType>
                                     </xsd:element>
                                     <xsd:element name="router_config_lines" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
@@ -940,10 +954,25 @@
                                                 <xsd:documentation>The routing protocol authentication type.</xsd:documentation>
                                           </xsd:annotation>
                                     </xsd:element>
-                                    <xsd:element name="ospf_area" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                                    <xsd:element name="ospf_area" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
                                                 <xsd:documentation>The OSPF area that is authenticated, if applicable.</xsd:documentation>
                                           </xsd:annotation>
+                                          <xsd:complexType>
+                                                <xsd:simpleContent>
+                                                      <xsd:restriction base="oval-def:EntityStateAnySimpleType">
+                                                            <xsd:attribute name="datatype" use="optional" default="int">
+                                                                  <xsd:simpleType>
+                                                                        <xsd:restriction base="oval:SimpleDatatypeEnumeration">
+                                                                              <xsd:enumeration value="int"/>
+                                                                              <xsd:enumeration value="ipv4_address"/>
+                                                                        </xsd:restriction>
+                                                                  </xsd:simpleType>
+                                                            </xsd:attribute>
+                                                      </xsd:restriction>
+                                                </xsd:simpleContent>
+                                          </xsd:complexType>
+ 
                                     </xsd:element>
                                     <xsd:element name="key_chain" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
@@ -2079,7 +2108,7 @@
             <xsd:annotation>
                   <xsd:documentation>The EntityStateAccessListUseType complex type restricts a
                         string value to a specific set of values: INTERFACE, CRYPTO_MAP_MATCH,
-                        CLASS_MAP_MATCH, ROUTE_MAP_MATCH, IGMP_FILTER, NONE. These values describe
+                        CLASS_MAP_MATCH, ROUTE_MAP_MATCH, IGMP_FILTER, VTY. These values describe
                         the ACL use in a Cisco IOS configuration. The empty string is also allowed
                         to support empty element associated with variable references. Note that when
                         using pattern matches and variables care must be taken to ensure that the
@@ -2093,7 +2122,18 @@
                         <xsd:enumeration value="CLASS_MAP_MATCH"/>
                         <xsd:enumeration value="ROUTE_MAP_MATCH"/>
                         <xsd:enumeration value="IGMP_FILTER"/>
-                        <xsd:enumeration value="NONE"/>
+                        <xsd:enumeration value="VTY"/>
+                        <xsd:enumeration value="NONE">
+                             <xsd:annotation>
+                                  <xsd:appinfo>
+                                       <oval:deprecated_info>
+                                            <oval:version>5.11.1:1.2</oval:version>
+                                            <oval:reason>The EntityStateSimpleBaseType check_existence attribute serves the same purpose as this enumeration value.</oval:reason>
+                                            <oval:comment>This AccessListUseType enumeration value has been deprecated and may be removed in a future version of the language.</oval:comment>
+                                       </oval:deprecated_info>
+                                  </xsd:appinfo>
+                             </xsd:annotation>
+                        </xsd:enumeration>
                         <xsd:enumeration value="">
                               <xsd:annotation>
                                     <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
@@ -2104,13 +2144,23 @@
       </xsd:complexType>
       <xsd:complexType name="EntityStateRoutingAuthTypeStringType">
             <xsd:annotation>
-                  <xsd:documentation>The EntityStateRoutingAuthTypeStringType complex type restricts a string value to a specific set of values: CLEARTEXT, MESSAGE_DIGEST, NULL. These values describe the routing protocol authentication types used in a Cisco IOS configuration. The empty string is also allowed to support empty element associated with variable references. Note that when using pattern matches and variables care must be taken to ensure that the regular expression and variable values align with the enumerated values.</xsd:documentation>
+                  <xsd:documentation>The EntityStateRoutingAuthTypeStringType complex type restricts a string value to a specific set of values: CLEARTEXT, MESSAGE_DIGEST. These values describe the routing protocol authentication types used in a Cisco IOS configuration. The empty string is also allowed to support empty element associated with variable references. Note that when using pattern matches and variables care must be taken to ensure that the regular expression and variable values align with the enumerated values.</xsd:documentation>
             </xsd:annotation>
             <xsd:simpleContent>
                   <xsd:restriction base="oval-def:EntityStateStringType">
                         <xsd:enumeration value="CLEARTEXT"/>
                         <xsd:enumeration value="MESSAGE_DIGEST"/>
-                        <xsd:enumeration value="NULL"/>
+                        <xsd:enumeration value="NULL">
+                             <xsd:annotation>
+                                  <xsd:appinfo>
+                                       <oval:deprecated_info>
+                                            <oval:version>5.11.1:1.2</oval:version>
+                                            <oval:reason>The NULL authentication area type is never declared in an interface ip ospf command context.</oval:reason>
+                                            <oval:comment>This RoutingAuthTypeStringType enumeration value has been deprecated and may be removed in a future version of the language.</oval:comment>
+                                       </oval:deprecated_info>
+                                  </xsd:appinfo>
+                             </xsd:annotation>
+                        </xsd:enumeration>
                         <xsd:enumeration value="">
                               <xsd:annotation>
                                     <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>

--- a/schemas/ios-definitions-schema.xsd
+++ b/schemas/ios-definitions-schema.xsd
@@ -2131,6 +2131,13 @@
                                             <oval:reason>The EntityStateSimpleBaseType check_existence attribute serves the same purpose as this enumeration value.</oval:reason>
                                             <oval:comment>This AccessListUseType enumeration value has been deprecated and may be removed in a future version of the language.</oval:comment>
                                        </oval:deprecated_info>
+                                       <sch:pattern id="ios-def_salut_none_value_dep">
+                                            <sch:rule context="oval-def:oval_definitions/oval-def:states/ios-def:acl_state/ios-def:use">
+                                                 <sch:report test=".='NONE'">
+                                                       DEPRECATED ELEMENT VALUE IN: acl_state ELEMENT VALUE: <sch:value-of select="."/>
+                                                 </sch:report>
+                                            </sch:rule>
+                                       </sch:pattern>
                                   </xsd:appinfo>
                              </xsd:annotation>
                         </xsd:enumeration>
@@ -2158,6 +2165,13 @@
                                             <oval:reason>The NULL authentication area type is never declared in an interface ip ospf command context.</oval:reason>
                                             <oval:comment>This RoutingAuthTypeStringType enumeration value has been deprecated and may be removed in a future version of the language.</oval:comment>
                                        </oval:deprecated_info>
+                                       <sch:pattern id="ios-def_sratst_null_value_dep">
+                                            <sch:rule context="oval-def:oval_definitions/oval-def:states/ios-def:routingprotocolauthintf_state/ios-def:auth_type">
+                                                 <sch:report test=".='NULL'">
+                                                       DEPRECATED ELEMENT VALUE IN: acl_state ELEMENT VALUE: <sch:value-of select="."/>
+                                                 </sch:report>
+                                            </sch:rule>
+                                       </sch:pattern>
                                   </xsd:appinfo>
                              </xsd:annotation>
                         </xsd:enumeration>

--- a/schemas/ios-definitions-schema.xsd
+++ b/schemas/ios-definitions-schema.xsd
@@ -2168,7 +2168,7 @@
                                        <sch:pattern id="ios-def_sratst_null_value_dep">
                                             <sch:rule context="oval-def:oval_definitions/oval-def:states/ios-def:routingprotocolauthintf_state/ios-def:auth_type">
                                                  <sch:report test=".='NULL'">
-                                                       DEPRECATED ELEMENT VALUE IN: acl_state ELEMENT VALUE: <sch:value-of select="."/>
+                                                       DEPRECATED ELEMENT VALUE IN: routingprotocolauthintf_state ELEMENT VALUE: <sch:value-of select="."/>
                                                  </sch:report>
                                             </sch:rule>
                                        </sch:pattern>

--- a/schemas/ios-system-characteristics-schema.xsd
+++ b/schemas/ios-system-characteristics-schema.xsd
@@ -384,10 +384,24 @@
                                         <xsd:documentation>Element with the BGP neighbors, if applicable.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
-                              <xsd:element name="ospf_authentication_area" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="unbounded">
+                              <xsd:element name="ospf_authentication_area" minOccurs="0" maxOccurs="unbounded">
                                    <xsd:annotation>
                                         <xsd:documentation>Element with the OSPF area that is authenticated, if applicable.</xsd:documentation>
                                    </xsd:annotation>
+                                   <xsd:complexType>
+                                         <xsd:simpleContent>
+                                               <xsd:restriction base="oval-sc:EntityItemAnySimpleType">
+                                                     <xsd:attribute name="datatype" use="optional" default="int">
+                                                           <xsd:simpleType>
+                                                                 <xsd:restriction base="oval:SimpleDatatypeEnumeration">
+                                                                       <xsd:enumeration value="int"/>
+                                                                       <xsd:enumeration value="ipv4_address"/>
+                                                                 </xsd:restriction>
+                                                           </xsd:simpleType>
+                                                     </xsd:attribute>
+                                               </xsd:restriction>
+                                         </xsd:simpleContent>
+                                   </xsd:complexType>
                               </xsd:element>
                               <xsd:element name="router_config_lines" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
@@ -430,10 +444,24 @@
                                         <xsd:documentation>Element with the routing protocol authentication type.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
-                              <xsd:element name="ospf_area" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                              <xsd:element name="ospf_area" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>Element with the OSPF area that is authenticated, if applicable.</xsd:documentation>
                                    </xsd:annotation>
+                                   <xsd:complexType>
+                                         <xsd:simpleContent>
+                                               <xsd:restriction base="oval-sc:EntityItemAnySimpleType">
+                                                     <xsd:attribute name="datatype" use="optional" default="int">
+                                                           <xsd:simpleType>
+                                                                 <xsd:restriction base="oval:SimpleDatatypeEnumeration">
+                                                                       <xsd:enumeration value="int"/>
+                                                                       <xsd:enumeration value="ipv4_address"/>
+                                                                 </xsd:restriction>
+                                                           </xsd:simpleType>
+                                                     </xsd:attribute>
+                                               </xsd:restriction>
+                                         </xsd:simpleContent>
+                                   </xsd:complexType>
                               </xsd:element>
                               <xsd:element name="key_chain" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
@@ -881,7 +909,7 @@
           <xsd:annotation>
                <xsd:documentation>The EntityItemAccessListUseType complex type restricts a string
                     value to a specific set of values: INTERFACE, CRYPTO_MAP_MATCH, CLASS_MAP_MATCH,
-                    ROUTE_MAP_MATCH, IGMP_FILTER, NONE. These values describe the ACL use in a Cisco
+                    ROUTE_MAP_MATCH, IGMP_FILTER, VTY. These values describe the ACL use in a Cisco
                     IOS configuration.  The empty string is also allowed to support empty elements
                     associated with error conditions.</xsd:documentation>
           </xsd:annotation>
@@ -892,7 +920,18 @@
                     <xsd:enumeration value="CLASS_MAP_MATCH"/>
                     <xsd:enumeration value="ROUTE_MAP_MATCH"/>
                     <xsd:enumeration value="IGMP_FILTER"/>
-                    <xsd:enumeration value="NONE"/>
+                    <xsd:enumeration value="VTY"/>
+                    <xsd:enumeration value="NONE">
+                         <xsd:annotation>
+                              <xsd:appinfo>
+                                   <oval:deprecated_info>
+                                        <oval:version>5.11.1:1.2</oval:version>
+                                        <oval:reason>The EntityStateSimpleBaseType check_existence attribute serves the same purpose as this enumeration value.</oval:reason>
+                                        <oval:comment>This AccessListUseType enumeration value has been deprecated and may be removed in a future version of the language.</oval:comment>
+                                   </oval:deprecated_info>
+                              </xsd:appinfo>
+                         </xsd:annotation>
+                    </xsd:enumeration>
                     <xsd:enumeration value="">
                          <xsd:annotation>
                               <xsd:documentation>The empty string value is permitted here to allow for detailed error reporting.</xsd:documentation>
@@ -903,13 +942,23 @@
      </xsd:complexType>
      <xsd:complexType name="EntityItemRoutingAuthTypeStringType">
           <xsd:annotation>
-               <xsd:documentation>The EntityItemRoutingAuthTypeStringType complex type restricts a string value to a specific set of values: CLEARTEXT, MESSAGE_DIGEST, NULL. These values describe the routing protocol authentication types used in a Cisco IOS configuration. The empty string is also allowed to support empty elements associated with error conditions.</xsd:documentation>
+               <xsd:documentation>The EntityItemRoutingAuthTypeStringType complex type restricts a string value to a specific set of values: CLEARTEXT, MESSAGE_DIGEST. These values describe the routing protocol authentication types used in a Cisco IOS configuration. The empty string is also allowed to support empty elements associated with error conditions.</xsd:documentation>
           </xsd:annotation>
           <xsd:simpleContent>
                <xsd:restriction base="oval-sc:EntityItemStringType">
                     <xsd:enumeration value="CLEARTEXT"/>
                     <xsd:enumeration value="MESSAGE_DIGEST"/>
-                    <xsd:enumeration value="NULL"/>
+                    <xsd:enumeration value="NULL">
+                        <xsd:annotation>
+                             <xsd:appinfo>
+                                  <oval:deprecated_info>
+                                       <oval:version>5.11.1:1.2</oval:version>
+                                       <oval:reason>The NULL authentication area type is never declared in an interface ip ospf command context.</oval:reason>
+                                       <oval:comment>This RoutingAuthTypeStringType enumeration value has been deprecated and may be removed in a future version of the language.</oval:comment>
+                                  </oval:deprecated_info>
+                             </xsd:appinfo>
+                        </xsd:annotation>
+                    </xsd:enumeration>
                     <xsd:enumeration value="">
                          <xsd:annotation>
                               <xsd:documentation>The empty string value is permitted here to allow for detailed error reporting.</xsd:documentation>

--- a/schemas/ios-system-characteristics-schema.xsd
+++ b/schemas/ios-system-characteristics-schema.xsd
@@ -7,7 +7,7 @@
           <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
           <xsd:appinfo>
                <schema>IOS System Characteristics</schema>
-               <version>5.11.1:1.1</version>
+               <version>5.11.1:1.2</version>
                <date>4/22/2015 09:00:00 AM</date>
                <terms_of_use>Copyright (c) 2002-2015, The MITRE Corporation. All rights reserved.  The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema.  When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
                <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>

--- a/schemas/ios-system-characteristics-schema.xsd
+++ b/schemas/ios-system-characteristics-schema.xsd
@@ -415,7 +415,7 @@
                                         <xsd:documentation>Element with the interface.</xsd:documentation>
                                    </xsd:annotation>
                               </xsd:element>
-                              <xsd:element name="protocol" type="ios-sc:EntityItemRoutingProtocolType" minOccurs="0" maxOccurs="unbounded">
+                              <xsd:element name="protocol" type="ios-sc:EntityItemRoutingProtocolType" minOccurs="0" maxOccurs="1">
                                    <xsd:annotation>
                                         <xsd:documentation>Element with the routing protocol.</xsd:documentation>
                                    </xsd:annotation>

--- a/schemas/iosxe-definitions-schema.xsd
+++ b/schemas/iosxe-definitions-schema.xsd
@@ -261,41 +261,106 @@
                         <xsd:element name="platform" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The platform that is running the IOS-XE software. For example if could be asr1000. </xsd:documentation>
+                                <xsd:appinfo>
+                                    <oval:deprecated_info>
+                                        <oval:version>5.11.1:1.2</oval:version>
+                                        <oval:reason>This entity has been deprecated because it cannot be reliably collected.</oval:reason>
+                                    </oval:deprecated_info>
+                                    <sch:pattern id="iosxe-def_versionste_platform_dep">
+                                        <sch:rule context="iosxe-def:version_state/iosxe-def:platformrp">
+                                            <sch:report test="true()">Warning: DEPRECATED ENTITY: <sch:value-of select="name()"/>. This entity has been deprecated because it cannot be reliably collected.</sch:report>
+                                        </sch:rule>
+                                    </sch:pattern>
+                                </xsd:appinfo>
                             </xsd:annotation>
                         </xsd:element>
                         <xsd:element name="rp" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The routing processor running the IOS-XE software.</xsd:documentation>
+                                <xsd:appinfo>
+                                    <oval:deprecated_info>
+                                        <oval:version>5.11.1:1.2</oval:version>
+                                        <oval:reason>This entity has been deprecated because it cannot be reliably collected.</oval:reason>
+                                    </oval:deprecated_info>
+                                    <sch:pattern id="iosxe-def_versionste_rp_dep">
+                                        <sch:rule context="iosxe-def:version_state/iosxe-def:rp">
+                                            <sch:report test="true()">Warning: DEPRECATED ENTITY: <sch:value-of select="name()"/>. This entity has been deprecated because it cannot be reliably collected.</sch:report>
+                                        </sch:rule>
+                                    </sch:pattern>
+                                </xsd:appinfo>
                             </xsd:annotation>
                         </xsd:element>
                         <xsd:element name="pkg" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The consolidated IOS-XE packages in the image. For example it could be adventservicesk9.</xsd:documentation>
+                                <xsd:appinfo>
+                                    <oval:deprecated_info>
+                                        <oval:version>5.11.1:1.2</oval:version>
+                                        <oval:reason>This entity has been deprecated because it cannot be reliably collected.</oval:reason>
+                                    </oval:deprecated_info>
+                                    <sch:pattern id="iosxe-def_versionste_pkg_dep">
+                                        <sch:rule context="iosxe-def:version_state/iosxe-def:pkg">
+                                            <sch:report test="true()">Warning: DEPRECATED ENTITY: <sch:value-of select="name()"/>. This entity has been deprecated because it cannot be reliably collected.</sch:report>
+                                        </sch:rule>
+                                    </sch:pattern>
+                                </xsd:appinfo>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="version_string" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The entire IOS-XE version string, for example, '03.13.02.S'.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
                         <xsd:element name="major_release" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
-                                <xsd:documentation>The major version piece of the version string. The value is an integer and in the example ASR1000rp1-ipbasek9.03.04.02.122-33.SR.bin the major_release is '03'.</xsd:documentation>
+                                <xsd:documentation>The major version piece of the version string. The value is an integer, and in the example 03.13.02.S the major_release is '3'</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
                         <xsd:element name="release" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
-                                <xsd:documentation>The release piece of the version string. The value is an integer and in the example ASR1000rp1-ipbasek9.03.04.02.122-33.SR.bin the release version is '04'</xsd:documentation>
+                                <xsd:documentation>The minor release piece of the version string. The value is an integer, and in the example 03.13.02.S the release is '13'</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
                         <xsd:element name="rebuild" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
-                                <xsd:documentation>The release piece of the version string. The value is an integer and in the example ASR1000rp1-ipbasek9.03.04.02.122-33.SR.bin the rebuild is '02'</xsd:documentation>
+                                <xsd:documentation>The rebuild piece of the version string. The value is an integer, and in the example 03.13.02.S the rebuild is '2'</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="train" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The train piece of the version string. The value is a string, and in the example 03.13.02.S the train is 'S'</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
                         <xsd:element name="ios_release" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
-                                <xsd:documentation>The IOS release the IOS-XE was derived from. The value is an string and in the example ASR1000rp1-ipbasek9.03.04.02.122-33.SR.bin the ios_release version is '122-33'</xsd:documentation>
+                                <xsd:documentation>The IOS release the IOS-XE was derived from. The value is a string and in the example ASR1000rp1-ipbasek9.03.04.02.122-33.SR.bin the ios_release version is '122-33'</xsd:documentation>
+                                <xsd:appinfo>
+                                    <oval:deprecated_info>
+                                        <oval:version>5.11.1:1.2</oval:version>
+                                        <oval:reason>This entity has been deprecated because it is irrelevant to the IOS-XE version.</oval:reason>
+                                    </oval:deprecated_info>
+                                    <sch:pattern id="iosxe-def_versionste_ios_release_dep">
+                                        <sch:rule context="iosxe-def:version_state/iosxe-def:ios_release">
+                                            <sch:report test="true()">Warning: DEPRECATED ENTITY: <sch:value-of select="name()"/>. This entity has been deprecated because it is irrelevant to the IOS-XE version.</sch:report>
+                                        </sch:rule>
+                                    </sch:pattern>
+                                </xsd:appinfo>
                             </xsd:annotation>
                         </xsd:element>
                         <xsd:element name="ios_train" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The IOS release the IOS-XE was derived from. The value is an integer and in the example ASR1000rp1-ipbasek9.03.04.02.122-33.SR.bin the ios_release version is 'SR'</xsd:documentation>
+                                <xsd:appinfo>
+                                    <oval:deprecated_info>
+                                        <oval:version>5.11.1:1.2</oval:version>
+                                        <oval:reason>This entity has been deprecated because it is irrelevant to the IOS-XE version.</oval:reason>
+                                    </oval:deprecated_info>
+                                    <sch:pattern id="iosxe-def_versionste_ios_train_dep">
+                                        <sch:rule context="iosxe-def:version_state/iosxe-def:ios_train">
+                                            <sch:report test="true()">Warning: DEPRECATED ENTITY: <sch:value-of select="name()"/>. This entity has been deprecated because it is irrelevant to the IOS-XE version.</sch:report>
+                                        </sch:rule>
+                                    </sch:pattern>
+                                </xsd:appinfo>
                             </xsd:annotation>
                         </xsd:element>
                     </xsd:sequence>

--- a/schemas/iosxe-definitions-schema.xsd
+++ b/schemas/iosxe-definitions-schema.xsd
@@ -725,10 +725,24 @@
                                 <xsd:documentation>The BGP neighbors, if applicable.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
-                        <xsd:element name="ospf_authentication_area" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                        <xsd:element name="ospf_authentication_area" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The OSPF area that is authenticated, if applicable.</xsd:documentation>
                             </xsd:annotation>
+                            <xsd:complexType>
+                                <xsd:simpleContent>
+                                    <xsd:restriction base="oval-def:EntityStateAnySimpleType">
+                                        <xsd:attribute name="datatype" use="optional" default="int">
+                                            <xsd:simpleType>
+                                                <xsd:restriction base="oval:SimpleDatatypeEnumeration">
+                                                    <xsd:enumeration value="int"/>
+                                                    <xsd:enumeration value="ipv4_address"/>
+                                                </xsd:restriction>
+                                            </xsd:simpleType>
+                                        </xsd:attribute>
+                                    </xsd:restriction>
+                                </xsd:simpleContent>
+                            </xsd:complexType>
                         </xsd:element>
                         <xsd:element name="router_config_lines" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
@@ -944,10 +958,24 @@
                                 <xsd:documentation>The routing protocol authentication type.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
-                        <xsd:element name="ospf_area" type="oval-def:EntityStateIntType" minOccurs="0" maxOccurs="1">
+                        <xsd:element name="ospf_area" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The OSPF area that is authenticated, if applicable.</xsd:documentation>
                             </xsd:annotation>
+                            <xsd:complexType>
+                                <xsd:simpleContent>
+                                    <xsd:restriction base="oval-def:EntityStateAnySimpleType">
+                                        <xsd:attribute name="datatype" use="optional" default="int">
+                                            <xsd:simpleType>
+                                                <xsd:restriction base="oval:SimpleDatatypeEnumeration">
+                                                    <xsd:enumeration value="int"/>
+                                                    <xsd:enumeration value="ipv4_address"/>
+                                                </xsd:restriction>
+                                            </xsd:simpleType>
+                                        </xsd:attribute>
+                                    </xsd:restriction>
+                                </xsd:simpleContent>
+                            </xsd:complexType>
                         </xsd:element>
                         <xsd:element name="key_chain" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
@@ -1756,13 +1784,24 @@
     </xsd:complexType>
     <xsd:complexType name="EntityStateRoutingAuthTypeStringType">
         <xsd:annotation>
-            <xsd:documentation>The EntityStateRoutingAuthTypeStringType complex type restricts a string value to a specific set of values: CLEARTEXT, MESSAGE_DIGEST, NULL. These values describe the routing protocol authentication types used in a Cisco IOS-XE configuration. The empty string is also allowed to support empty element associated with variable references. Note that when using pattern matches and variables care must be taken to ensure that the regular expression and variable values align with the enumerated values.</xsd:documentation>
+            <xsd:documentation>The EntityStateRoutingAuthTypeStringType complex type restricts a string value to a specific set of values: CLEARTEXT, MESSAGE_DIGEST. These values describe the routing protocol authentication types used in a Cisco IOS-XE configuration. The empty string is also allowed to support empty element associated with variable references. Note that when using pattern matches and variables care must be taken to ensure that the regular expression and variable values align with the enumerated values.</xsd:documentation>
         </xsd:annotation>
         <xsd:simpleContent>
             <xsd:restriction base="oval-def:EntityStateStringType">
                 <xsd:enumeration value="CLEARTEXT"/>
                 <xsd:enumeration value="MESSAGE_DIGEST"/>
-                <xsd:enumeration value="NULL"/>
+                <xsd:enumeration value="NULL">
+                     <xsd:annotation>
+                          <xsd:appinfo>
+                               <oval:deprecated_info>
+                                    <oval:version>5.11.1:1.2</oval:version>
+                                    <oval:reason>The NULL authentication area type is never declared in an interface ip ospf command context.</oval:reason>
+                                    <oval:comment>This RoutingAuthTypeStringType enumeration value has been deprecated and may be removed in a future version of the language.</oval:comment>
+                               </oval:deprecated_info>
+                          </xsd:appinfo>
+                     </xsd:annotation>
+                </xsd:enumeration>
+
                 <xsd:enumeration value="">
                     <xsd:annotation>
                         <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>
@@ -1872,7 +1911,7 @@
     </xsd:complexType>
     <xsd:complexType name="EntityStateAccessListUseType">
         <xsd:annotation>
-            <xsd:documentation>The EntityStateAccessListUseType complex type restricts a string value to a specific set of values: INTERFACE, CRYPTO_MAP_MATCH, CLASS_MAP_MATCH, ROUTE_MAP_MATCH, IGMP_FILTER, NONE. These values describe the ACL use in a Cisco IOS-XE configuration. The empty string is also allowed to support empty element associated with variable references. Note that when using pattern matches and variables care must be taken to ensure that the regular expression and variable values align with the enumerated values.</xsd:documentation>
+            <xsd:documentation>The EntityStateAccessListUseType complex type restricts a string value to a specific set of values: INTERFACE, CRYPTO_MAP_MATCH, CLASS_MAP_MATCH, ROUTE_MAP_MATCH, IGMP_FILTER, VTY. These values describe the ACL use in a Cisco IOS-XE configuration. The empty string is also allowed to support empty element associated with variable references. Note that when using pattern matches and variables care must be taken to ensure that the regular expression and variable values align with the enumerated values.</xsd:documentation>
         </xsd:annotation>
         <xsd:simpleContent>
             <xsd:restriction base="oval-def:EntityStateStringType">
@@ -1881,7 +1920,18 @@
                 <xsd:enumeration value="CLASS_MAP_MATCH"/>
                 <xsd:enumeration value="ROUTE_MAP_MATCH"/>
                 <xsd:enumeration value="IGMP_FILTER"/>
-                <xsd:enumeration value="NONE"/>
+                <xsd:enumeration value="VTY"/>
+                <xsd:enumeration value="NONE">
+                     <xsd:annotation>
+                          <xsd:appinfo>
+                               <oval:deprecated_info>
+                                    <oval:version>5.11.1:1.2</oval:version>
+                                    <oval:reason>The EntityStateSimpleBaseType check_existence attribute serves the same purpose as this enumeration value.</oval:reason>
+                                    <oval:comment>This AccessListUseType enumeration value has been deprecated and may be removed in a future version of the language.</oval:comment>
+                               </oval:deprecated_info>
+                          </xsd:appinfo>
+                     </xsd:annotation>
+                </xsd:enumeration>
                 <xsd:enumeration value="">
                     <xsd:annotation>
                         <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with variable references.</xsd:documentation>

--- a/schemas/iosxe-definitions-schema.xsd
+++ b/schemas/iosxe-definitions-schema.xsd
@@ -267,7 +267,7 @@
                                         <oval:reason>This entity has been deprecated because it cannot be reliably collected.</oval:reason>
                                     </oval:deprecated_info>
                                     <sch:pattern id="iosxe-def_versionste_platform_dep">
-                                        <sch:rule context="iosxe-def:version_state/iosxe-def:platformrp">
+                                        <sch:rule context="iosxe-def:version_state/iosxe-def:platform">
                                             <sch:report test="true()">Warning: DEPRECATED ENTITY: <sch:value-of select="name()"/>. This entity has been deprecated because it cannot be reliably collected.</sch:report>
                                         </sch:rule>
                                     </sch:pattern>
@@ -384,11 +384,11 @@
             </xsd:appinfo>
             <xsd:appinfo>
                 <sch:pattern id="iosxe-def_interfacetst">
-                    <sch:rule context="iosxe-def:interface_test/ios-def:object">
-                        <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/ios-def:interface_object/@id"><sch:value-of select="../@id"/> - the object child element of an interface_test must reference an interface_object</sch:assert>
+                    <sch:rule context="iosxe-def:interface_test/iosxe-def:object">
+                        <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/iosxe-def:interface_object/@id"><sch:value-of select="../@id"/> - the object child element of an interface_test must reference an interface_object</sch:assert>
                     </sch:rule>
-                    <sch:rule context="iosxe-def:interface_test/ios-def:state">
-                        <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/ios-def:interface_state/@id"><sch:value-of select="../@id"/> - the state child element of an interface_test must reference an interface_state</sch:assert>
+                    <sch:rule context="iosxe-def:interface_test/iosxe-def:state">
+                        <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/iosxe-def:interface_state/@id"><sch:value-of select="../@id"/> - the state child element of an interface_test must reference an interface_state</sch:assert>
                     </sch:rule>
                 </sch:pattern>
             </xsd:appinfo>
@@ -1863,6 +1863,13 @@
                                     <oval:reason>The NULL authentication area type is never declared in an interface ip ospf command context.</oval:reason>
                                     <oval:comment>This RoutingAuthTypeStringType enumeration value has been deprecated and may be removed in a future version of the language.</oval:comment>
                                </oval:deprecated_info>
+                               <sch:pattern id="iosxe-def_sratst_null_value_dep">
+                                    <sch:rule context="oval-def:oval_definitions/oval-def:states/iosxe-def:routingprotocolauthintf_state/iosxe-def:auth_type">
+                                         <sch:report test=".='NULL'">
+                                               DEPRECATED ELEMENT VALUE IN: routingprotocolauthintf_state ELEMENT VALUE: <sch:value-of select="."/>
+                                         </sch:report>
+                                    </sch:rule>
+                               </sch:pattern>
                           </xsd:appinfo>
                      </xsd:annotation>
                 </xsd:enumeration>
@@ -1994,6 +2001,13 @@
                                     <oval:reason>The EntityStateSimpleBaseType check_existence attribute serves the same purpose as this enumeration value.</oval:reason>
                                     <oval:comment>This AccessListUseType enumeration value has been deprecated and may be removed in a future version of the language.</oval:comment>
                                </oval:deprecated_info>
+                               <sch:pattern id="iosxe-def_salut_none_value_dep">
+                                    <sch:rule context="oval-def:oval_definitions/oval-def:states/iosxe-def:acl_state/iosxe-def:use">
+                                         <sch:report test=".='NONE'">
+                                               DEPRECATED ELEMENT VALUE IN: acl_state ELEMENT VALUE: <sch:value-of select="."/>
+                                         </sch:report>
+                                    </sch:rule>
+                               </sch:pattern>
                           </xsd:appinfo>
                      </xsd:annotation>
                 </xsd:enumeration>

--- a/schemas/iosxe-definitions-schema.xsd
+++ b/schemas/iosxe-definitions-schema.xsd
@@ -8,7 +8,7 @@
         <xsd:documentation>Thanks to Omar Santos and Panos Kampanakis of Cisco for providing this test.</xsd:documentation>
         <xsd:appinfo>
             <schema>IOS-XE Definition</schema>
-            <version>5.11.1:1.1</version>
+            <version>5.11.1:1.2</version>
             <date>4/22/2015 09:00:00 AM</date>
             <terms_of_use>Copyright (c) 2002-2015, The MITRE Corporation. All rights reserved.  The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema.  When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
             <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>

--- a/schemas/iosxe-system-characteristics-schema.xsd
+++ b/schemas/iosxe-system-characteristics-schema.xsd
@@ -77,41 +77,106 @@
                         <xsd:element name="platform" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The platform entity specifies the platform that is running the IOS-XE software. For example if could be asr1000. </xsd:documentation>
+                                <xsd:appinfo>
+                                    <oval:deprecated_info>
+                                        <oval:version>5.11.1:1.2</oval:version>
+                                        <oval:reason>This entity has been deprecated because it cannot reliably be collected.</oval:reason>
+                                    </oval:deprecated_info>
+                                    <sch:pattern id="iosxe-sc_versionitem_platform">
+                                        <sch:rule context="iosxe-sc:version_item/iosxe-sc:platform">
+                                            <sch:report test="true()">Warning: DEPRECATED ENTITY: <sch:value-of select="name()"/>. This entity has been deprecated because it cannot be reliably collected.</sch:report>
+                                        </sch:rule>
+                                    </sch:pattern>
+                                </xsd:appinfo>
                             </xsd:annotation>
                         </xsd:element>
                         <xsd:element name="rp" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The rp entity specifies the routing processor running the IOS-XE software.</xsd:documentation>
+                                <xsd:appinfo>
+                                    <oval:deprecated_info>
+                                        <oval:version>5.11.1:1.2</oval:version>
+                                        <oval:reason>This entity has been deprecated because it cannot reliably be collected.</oval:reason>
+                                    </oval:deprecated_info>
+                                    <sch:pattern id="iosxe-sc_versionitem_rp">
+                                        <sch:rule context="iosxe-sc:version_item/iosxe-sc:rp">
+                                            <sch:report test="true()">Warning: DEPRECATED ENTITY: <sch:value-of select="name()"/>. This entity has been deprecated because it cannot be reliably collected.</sch:report>
+                                        </sch:rule>
+                                    </sch:pattern>
+                                </xsd:appinfo>
                             </xsd:annotation>
                         </xsd:element>
                         <xsd:element name="pkg" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The pkg entity specifies the consolidated IOS-XE packages in the image. For example it could be adventservicesk9.</xsd:documentation>
+                                <xsd:appinfo>
+                                    <oval:deprecated_info>
+                                        <oval:version>5.11.1:1.2</oval:version>
+                                        <oval:reason>This entity has been deprecated because it cannot reliably be collected.</oval:reason>
+                                    </oval:deprecated_info>
+                                    <sch:pattern id="iosxe-sc_versionitem_pkg">
+                                        <sch:rule context="iosxe-sc:version_item/iosxe-sc:pkg">
+                                            <sch:report test="true()">Warning: DEPRECATED ENTITY: <sch:value-of select="name()"/>. This entity has been deprecated because it cannot be reliably collected.</sch:report>
+                                        </sch:rule>
+                                    </sch:pattern>
+                                </xsd:appinfo>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="version_string" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The train entity specifies the entire IOS-XE version string, for example, '03.13.02.S'.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
                         <xsd:element name="major_release" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
-                                <xsd:documentation>The major_release entity specifies the major version piece of the version string. The value is an integer and in the example ASR1000rp1-ipbasek9.03.04.02.122-33.SR.bin the major_release is '03'.</xsd:documentation>
+                                <xsd:documentation>The major_release entity specifies the major version piece of the version string. The value is an integer and in the example 03.13.02.S the major_release is '3'.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
                         <xsd:element name="release" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
-                                <xsd:documentation>The release entity specifies the release piece of the version string. The value is an integer and in the example ASR1000rp1-ipbasek9.03.04.02.122-33.SR.bin the release version is '04'</xsd:documentation>
+                                <xsd:documentation>The release entity specifies the release piece of the version string. The value is an integer and in the example 03.13.02.S the release version is '13'.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
                         <xsd:element name="rebuild" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
-                                <xsd:documentation>The rebuild entity specifies the release piece of the version string. The value is an integer and in the example ASR1000rp1-ipbasek9.03.04.02.122-33.SR.bin the rebuild is '02'</xsd:documentation>
+                                <xsd:documentation>The rebuild entity specifies the release piece of the version string. The value is an integer and in the example 03.13.02.S the rebuild is '2'.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="train" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The train entity specifies the train piece of the version string. The value is a string and in the example 03.13.02.S the train is 'S'.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
                         <xsd:element name="ios_release" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The ios_release entity specifies the IOS release the IOS-XE was derived from. The value is an string and in the example ASR1000rp1-ipbasek9.03.04.02.122-33.SR.bin the ios_release version is '122-33'</xsd:documentation>
+                                <xsd:appinfo>
+                                    <oval:deprecated_info>
+                                        <oval:version>5.11.1:1.2</oval:version>
+                                        <oval:reason>This entity has been deprecated because it is irrelevant to the IOS-XE version..</oval:reason>
+                                    </oval:deprecated_info>
+                                    <sch:pattern id="iosxe-sc_versionitem_ios_release">
+                                        <sch:rule context="iosxe-sc:version_item/iosxe-sc:ios_release">
+                                            <sch:report test="true()">Warning: DEPRECATED ENTITY: <sch:value-of select="name()"/>. This entity has been deprecated because it is irrelevant to the IOS-XE version.</sch:report>
+                                        </sch:rule>
+                                    </sch:pattern>
+                                </xsd:appinfo>
                             </xsd:annotation>
                         </xsd:element>
                         <xsd:element name="ios_train" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>The ios_train entity specifies the IOS release the IOS-XE was derived from. The value is an integer and in the example ASR1000rp1-ipbasek9.03.04.02.122-33.SR.bin the ios_release version is 'SR'</xsd:documentation>
+                                <xsd:appinfo>
+                                    <oval:deprecated_info>
+                                        <oval:version>5.11.1:1.2</oval:version>
+                                        <oval:reason>This entity has been deprecated because it cannot reliably be collected.</oval:reason>
+                                    </oval:deprecated_info>
+                                    <sch:pattern id="iosxe-sc_versionitem_ios_train">
+                                        <sch:rule context="iosxe-sc:version_item/iosxe-sc:ios_train">
+                                            <sch:report test="true()">Warning: DEPRECATED ENTITY: <sch:value-of select="name()"/>. This entity has been deprecated because it is irrelevant to the IOS-XE version.</sch:report>
+                                        </sch:rule>
+                                    </sch:pattern>
+                                </xsd:appinfo>
                             </xsd:annotation>
                         </xsd:element>
                     </xsd:sequence>

--- a/schemas/iosxe-system-characteristics-schema.xsd
+++ b/schemas/iosxe-system-characteristics-schema.xsd
@@ -336,10 +336,24 @@
                                 <xsd:documentation>Element with the BGP neighbors, if applicable.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
-                        <xsd:element name="ospf_authentication_area" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="unbounded">
+                        <xsd:element name="ospf_authentication_area" minOccurs="0" maxOccurs="unbounded">
                             <xsd:annotation>
                                 <xsd:documentation>Element with the OSPF area that is authenticated, if applicable.</xsd:documentation>
                             </xsd:annotation>
+                            <xsd:complexType>
+                                  <xsd:simpleContent>
+                                        <xsd:restriction base="oval-sc:EntityItemAnySimpleType">
+                                              <xsd:attribute name="datatype" use="optional" default="int">
+                                                    <xsd:simpleType>
+                                                          <xsd:restriction base="oval:SimpleDatatypeEnumeration">
+                                                                <xsd:enumeration value="int"/>
+                                                                <xsd:enumeration value="ipv4_address"/>
+                                                          </xsd:restriction>
+                                                    </xsd:simpleType>
+                                              </xsd:attribute>
+                                        </xsd:restriction>
+                                  </xsd:simpleContent>
+                            </xsd:complexType>
                         </xsd:element>
                         <xsd:element name="router_config_lines" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
@@ -408,10 +422,24 @@
                                 <xsd:documentation>Element with the routing protocol authentication type.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
-                        <xsd:element name="ospf_area" type="oval-sc:EntityItemIntType" minOccurs="0" maxOccurs="1">
+                        <xsd:element name="ospf_area" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>Element with the OSPF area that is authenticated, if applicable.</xsd:documentation>
                             </xsd:annotation>
+                            <xsd:complexType>
+                                <xsd:simpleContent>
+                                    <xsd:restriction base="oval-sc:EntityItemAnySimpleType">
+                                        <xsd:attribute name="datatype" use="optional" default="int">
+                                            <xsd:simpleType>
+                                                <xsd:restriction base="oval:SimpleDatatypeEnumeration">
+                                                    <xsd:enumeration value="int"/>
+                                                    <xsd:enumeration value="ipv4_address"/>
+                                                </xsd:restriction>
+                                            </xsd:simpleType>
+                                        </xsd:attribute>
+                                    </xsd:restriction>
+                                </xsd:simpleContent>
+                            </xsd:complexType>
                         </xsd:element>
                         <xsd:element name="key_chain" type="oval-sc:EntityItemStringType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
@@ -764,7 +792,7 @@
     <xsd:complexType name="EntityItemRoutingAuthTypeStringType">
         <xsd:annotation>
             <xsd:documentation>The EntityItemRoutingAuthTypeStringType complex type restricts a
-                string value to a specific set of values: CLEARTEXT, MESSAGE_DIGEST, NULL. These
+                string value to a specific set of values: CLEARTEXT, MESSAGE_DIGEST. These
                 values describe the routing protocol authentication types used in a Cisco IOS-XE
                 configuration. The empty string is also allowed to support empty element associated
                 with error conditions.</xsd:documentation>
@@ -773,7 +801,17 @@
             <xsd:restriction base="oval-sc:EntityItemStringType">
                 <xsd:enumeration value="CLEARTEXT"/>
                 <xsd:enumeration value="MESSAGE_DIGEST"/>
-                <xsd:enumeration value="NULL"/>
+                <xsd:enumeration value="NULL">
+                     <xsd:annotation>
+                          <xsd:appinfo>
+                               <oval:deprecated_info>
+                                    <oval:version>5.11.1:1.2</oval:version>
+                                    <oval:reason>The NULL authentication area type is never declared in an interface ip ospf command context.</oval:reason>
+                                    <oval:comment>This RoutingAuthTypeStringType enumeration value has been deprecated and may be removed in a future version of the language.</oval:comment>
+                               </oval:deprecated_info>
+                          </xsd:appinfo>
+                     </xsd:annotation>
+                </xsd:enumeration>
                 <xsd:enumeration value="">
                     <xsd:annotation>
                         <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with error conditions.</xsd:documentation>
@@ -907,7 +945,7 @@
         <xsd:annotation>
             <xsd:documentation>The EntityItemAccessListUseType complex type restricts a string value
                 to a specific set of values: INTERFACE, CRYPTO_MAP_MATCH, CLASS_MAP_MATCH,
-                ROUTE_MAP_MATCH, IGMP_FILTER, NONE. These values describe the ACL use in a Cisco
+                ROUTE_MAP_MATCH, IGMP_FILTER, VTY. These values describe the ACL use in a Cisco
                 IOS-XE configuration. The empty string is also allowed to support empty element
                 associated with error conditions.</xsd:documentation>
         </xsd:annotation>
@@ -918,7 +956,18 @@
                 <xsd:enumeration value="CLASS_MAP_MATCH"/>
                 <xsd:enumeration value="ROUTE_MAP_MATCH"/>
                 <xsd:enumeration value="IGMP_FILTER"/>
-                <xsd:enumeration value="NONE"/>
+                <xsd:enumeration value="VTY"/>
+                <xsd:enumeration value="NONE">
+                     <xsd:annotation>
+                          <xsd:appinfo>
+                               <oval:deprecated_info>
+                                    <oval:version>5.11.1:1.2</oval:version>
+                                    <oval:reason>The EntityStateSimpleBaseType check_existence attribute serves the same purpose as this enumeration value.</oval:reason>
+                                    <oval:comment>This AccessListUseType enumeration value has been deprecated and may be removed in a future version of the language.</oval:comment>
+                               </oval:deprecated_info>
+                          </xsd:appinfo>
+                     </xsd:annotation>
+                </xsd:enumeration>
                 <xsd:enumeration value="">
                     <xsd:annotation>
                         <xsd:documentation>The empty string value is permitted here to allow for empty elements associated with error conditions.</xsd:documentation>

--- a/schemas/iosxe-system-characteristics-schema.xsd
+++ b/schemas/iosxe-system-characteristics-schema.xsd
@@ -393,7 +393,7 @@
                                 <xsd:documentation>Element with the interface.</xsd:documentation>
                             </xsd:annotation>
                         </xsd:element>
-                        <xsd:element name="protocol" type="iosxe-sc:EntityItemRoutingProtocolType" minOccurs="0" maxOccurs="unbounded">
+                        <xsd:element name="protocol" type="iosxe-sc:EntityItemRoutingProtocolType" minOccurs="0" maxOccurs="1">
                             <xsd:annotation>
                                 <xsd:documentation>Element with the routing protocol.</xsd:documentation>
                             </xsd:annotation>

--- a/schemas/iosxe-system-characteristics-schema.xsd
+++ b/schemas/iosxe-system-characteristics-schema.xsd
@@ -153,7 +153,7 @@
                                 <xsd:appinfo>
                                     <oval:deprecated_info>
                                         <oval:version>5.11.1:1.2</oval:version>
-                                        <oval:reason>This entity has been deprecated because it is irrelevant to the IOS-XE version..</oval:reason>
+                                        <oval:reason>This entity has been deprecated because it is irrelevant to the IOS-XE version.</oval:reason>
                                     </oval:deprecated_info>
                                     <sch:pattern id="iosxe-sc_versionitem_ios_release">
                                         <sch:rule context="iosxe-sc:version_item/iosxe-sc:ios_release">

--- a/schemas/iosxe-system-characteristics-schema.xsd
+++ b/schemas/iosxe-system-characteristics-schema.xsd
@@ -8,7 +8,7 @@
         <xsd:documentation>Thanks to Omar Santos and Panos Kampanakis of Cisco for providing this test.</xsd:documentation>
         <xsd:appinfo>
             <schema>IOS-XE System Characteristics</schema>
-            <version>5.11.1:1.1</version>
+            <version>5.11.1:1.2</version>
             <date>4/22/2015 09:00:00 AM</date>
             <terms_of_use>Copyright (c) 2002-2015, The MITRE Corporation. All rights reserved.  The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema.  When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
             <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>

--- a/schemas/macos-definitions-schema.xsd
+++ b/schemas/macos-definitions-schema.xsd
@@ -7,7 +7,7 @@
             <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
             <xsd:appinfo>
                   <schema>MacOS Definition</schema>
-                  <version>5.11.1:1.1</version>
+                  <version>5.11.1:1.2</version>
                   <date>4/22/2015 09:00:00 AM</date>
                   <terms_of_use>Copyright (c) 2002-2015, The MITRE Corporation. All rights reserved. The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema. When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
                   <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
@@ -345,7 +345,7 @@
                   <xsd:complexContent>
                         <xsd:extension base="oval-def:StateType">
                               <xsd:sequence>
-                                    <xsd:element name="uuid" type="oval-def:EntityStateStringType">
+                                    <xsd:element name="uuid" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
                                                 <xsd:documentation>Specifies the UUID of the volume about which the plist information was retrieved.</xsd:documentation>
                                           </xsd:annotation>
@@ -1081,7 +1081,7 @@
                   <xsd:complexContent>
                         <xsd:extension base="oval-def:StateType">
                               <xsd:sequence>
-                                    <xsd:element name="label" type="oval-def:EntityStateStringType" minOccurs="1" maxOccurs="1">
+                                    <xsd:element name="label" type="oval-def:EntityStateStringType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
                                                 <xsd:documentation>Specifies the name of the agent/daemon used to create the object.</xsd:documentation>
                                           </xsd:annotation>
@@ -2258,7 +2258,7 @@
                   <xsd:complexContent>
                         <xsd:extension base="oval-def:StateType">
                               <xsd:sequence>
-                                    <xsd:element name="data_type" type="macos-def:EntityStateDataTypeType">
+                                    <xsd:element name="data_type" type="macos-def:EntityStateDataTypeType" minOccurs="0" maxOccurs="1">
                                           <xsd:annotation>
                                                 <xsd:documentation>The data_type entity provides the datatype value that is desired.</xsd:documentation>
                                           </xsd:annotation>

--- a/schemas/macos-system-characteristics-schema.xsd
+++ b/schemas/macos-system-characteristics-schema.xsd
@@ -7,7 +7,7 @@
           <xsd:documentation>The OVAL Schema is maintained by The MITRE Corporation and developed by the public OVAL Community. For more information, including how to get involved in the project and how to submit change requests, please visit the OVAL website at http://oval.mitre.org.</xsd:documentation>
           <xsd:appinfo>
                <schema>MacOS System Characteristics</schema>
-               <version>5.11.1:1.1</version>
+               <version>5.11.1:1.2</version>
                <date>4/22/2015 09:00:00 AM</date>
                 <terms_of_use>Copyright (c) 2002-2015, The MITRE Corporation. All rights reserved.  The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema.  When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
                <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>


### PR DESCRIPTION
This pull request includes a number of updates to Cisco OVAL platform schemas, necessary to address flaws introduced in changes from the OVAL 5.11 release.

It also includes a defect fix for the MacOS schema updates made in OVAL 5.11, which incorrectly specified minOccurs="1" for certain state entities.