### PR TITLE
fixing links in the readme to point to CIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Previous: [OVAL Archives] (http://oval.mitre.org/archive)<br>
 
 Experimental capabilities for the OVAL Language will be developed in the [OVAL Language Sandbox] (http://oval.mitre.org/language/sandbox.html) to allow the community to fully investigate and implement new capabilities before they are included here in an official release ensuring that only mature and implementable constructs are added to the OVAL Language. 
 
-Please see the [OVAL Web Site](http://oval.mitre.org) for more information about the OVAL Language.
+Please see the [OVAL Web Site](https://oval.cisecurity.org/) for more information about the OVAL Language.
 
-The OVAL Language operates under the [OVAL Terms of Use](http://oval.mitre.org/about/termsofuse.html). 
+The OVAL Language operates under the [OVAL Terms of Use](https://oval.cisecurity.org/terms). 


### PR DESCRIPTION
Changed the link to the "OVAL Website" to point to the CIS OVAL page. Changed the link to the "OVAL Terms of Use" to point to the CIS Terms of Use page.